### PR TITLE
Consistent error wrapping between stream and non-stream handlers

### DIFF
--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -516,14 +516,6 @@ defmodule LangChain.ChatModels.ChatAnthropic do
            original: response
          )}
 
-      {:error, %Req.Response{body: %{message: message}} = response} ->
-        {:error,
-         LangChainError.exception(
-           type: "unexpected_response",
-           message: message,
-           original: response
-         )}
-
       {:error, %Req.Response{} = response} ->
         {:error, LangChainError.exception(type: "unexpected_response", original: response)}
 

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -1497,8 +1497,6 @@ defmodule LangChain.ChatModels.ChatAnthropic do
     })
   end
 
-  defp get_token_usage(_usage_data), do: nil
-
   @doc """
   Generate a config map that can later restore the model's configuration.
   """

--- a/lib/chat_models/chat_anthropic.ex
+++ b/lib/chat_models/chat_anthropic.ex
@@ -595,6 +595,23 @@ defmodule LangChain.ChatModels.ChatAnthropic do
       {:ok, {:error, %LangChainError{} = error}} ->
         {:error, error}
 
+      {:ok, %Req.Response{status: 529}} ->
+        {:error, LangChainError.exception(type: "overloaded", message: "Overloaded")}
+
+      {:ok, %Req.Response{status: 429} = response} ->
+        {:error, LangChainError.rate_limit_exceeded(response)}
+
+      {:error, %Req.Response{body: %{message: message}} = response} ->
+        {:error,
+         LangChainError.exception(
+           type: "unexpected_response",
+           message: message,
+           original: response
+         )}
+
+      {:error, %Req.Response{} = response} ->
+        {:error, LangChainError.exception(type: "unexpected_response", original: response)}
+
       {:error, %Req.TransportError{reason: :timeout} = err} ->
         {:error,
          LangChainError.exception(type: "timeout", message: "Request timed out", original: err)}


### PR DESCRIPTION
Noticed the streaming version behaved differently to non-streaming for status code 400 responses.

Adds the same error wrapping logic added to the non-streaming version in https://github.com/altleague/langchain/pull/1/files#diff-4f49ed9a38128139b3cae85291b9b0389698781167ab1d378a4a492e9f00ef0cR407 to make them consistent.